### PR TITLE
Change `TexStudio-i18nProject` to `LocalizedMC`

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@ license="LGPL-2.1"
 modId="magnesium_extras" #mandatory
 version="${file.jarVersion}" #mandatory
 displayName="Magnesium/Rubidium Extras" #mandatory
-credits="TeamDeusVult, TexTrue, TexStudio-i18nProject" #optional
+credits="TeamDeusVult, TexTrue, LocalizedMC" #optional
 authors="Team Potato" #optional
 description='''
 Adds Extra Settings to Magnesium/Rubidium.


### PR DESCRIPTION
`TexStudio-i18nProject` has now been renamed `LocalizedMC`.